### PR TITLE
Fix odd eggs

### DIFF
--- a/data/events/odd_eggs.asm
+++ b/data/events/odd_eggs.asm
@@ -67,11 +67,10 @@ OddEggs:
 ;-------------------------------------------------------------------------------
 ; PICHU EGGS
 ;-------------------------------------------------------------------------------
-; PETAL_DANCE, SCARY_FACE, SING
 ; All 15 DVs
 	db PICHU
 	db NO_ITEM
-	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, ZAP_CANNON
+	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, PETAL_DANCE
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -81,7 +80,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 15, 15, 15, 15 ; DVs
-	db 30, 20, 10, 5 ; PP
+	db 30, 20, 10, 10 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -98,7 +97,7 @@ OddEggs:
 ; One 15 DV each
 	db PICHU
 	db NO_ITEM
-	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, ZAP_CANNON
+	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, SCARY_FACE
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -108,7 +107,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 15, 10, 10, 10 ; DVs
-	db 30, 20, 10, 5 ; PP
+	db 30, 20, 10, 10 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -124,7 +123,7 @@ OddEggs:
 
 	db PICHU
 	db NO_ITEM
-	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, ZAP_CANNON
+	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, SCARY_FACE
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -134,7 +133,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 10, 15, 10, 10 ; DVs
-	db 30, 20, 10, 5 ; PP
+	db 30, 20, 10, 10 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -150,7 +149,7 @@ OddEggs:
 
 	db PICHU
 	db NO_ITEM
-	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, ZAP_CANNON
+	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, SCARY_FACE
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -160,7 +159,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 10, 10, 15, 10 ; DVs
-	db 30, 20, 10, 5 ; PP
+	db 30, 20, 10, 10 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -176,7 +175,7 @@ OddEggs:
 
 	db PICHU
 	db NO_ITEM
-	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, ZAP_CANNON
+	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, SCARY_FACE
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -186,7 +185,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 10, 10, 10, 15 ; DVs
-	db 30, 20, 10, 5 ; PP
+	db 30, 20, 10, 10 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -203,7 +202,7 @@ OddEggs:
 ; No 15 DVs
 	db PICHU
 	db NO_ITEM
-	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, ZAP_CANNON
+	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, SING
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -213,7 +212,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 12, 12, 12, 12 ; DVs
-	db 30, 20, 10, 5 ; PP
+	db 30, 20, 10, 15 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -229,11 +228,10 @@ OddEggs:
 ;-------------------------------------------------------------------------------
 ; CLEFFA EGGS
 ;-------------------------------------------------------------------------------
-; PETAL_DANCE, SCARY_FACE, SWIFT
 ; All 15 DVs
 	db CLEFFA
 	db NO_ITEM
-	db POUND, CHARM, DIZZY_PUNCH, MOONBLAST
+	db POUND, CHARM, DIZZY_PUNCH, PETAL_DANCE
 	dw 00768 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -260,7 +258,7 @@ OddEggs:
 ; One DV of 15 each
 	db CLEFFA
 	db NO_ITEM
-	db POUND, CHARM, DIZZY_PUNCH, MOONBLAST
+	db POUND, CHARM, DIZZY_PUNCH, SCARY_FACE
 	dw 00768 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -286,7 +284,7 @@ OddEggs:
 
 	db CLEFFA
 	db NO_ITEM
-	db POUND, CHARM, DIZZY_PUNCH, MOONBLAST
+	db POUND, CHARM, DIZZY_PUNCH, SCARY_FACE
 	dw 00768 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -312,7 +310,7 @@ OddEggs:
 
 	db CLEFFA
 	db NO_ITEM
-	db POUND, CHARM, DIZZY_PUNCH, MOONBLAST
+	db POUND, CHARM, DIZZY_PUNCH, SCARY_FACE
 	dw 00768 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -338,7 +336,7 @@ OddEggs:
 
 	db CLEFFA
 	db NO_ITEM
-	db POUND, CHARM, DIZZY_PUNCH, MOONBLAST
+	db POUND, CHARM, DIZZY_PUNCH, SCARY_FACE
 	dw 00768 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -365,7 +363,7 @@ OddEggs:
 ; No 15 DVs
 	db CLEFFA
 	db NO_ITEM
-	db POUND, CHARM, DIZZY_PUNCH, MOONBLAST
+	db POUND, CHARM, DIZZY_PUNCH, SWIFT
 	dw 00768 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -375,7 +373,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 12, 12, 12, 12 ; DVs
-	db 35, 20, 10, 10 ; PP
+	db 35, 20, 10, 20 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -391,11 +389,10 @@ OddEggs:
 ;-------------------------------------------------------------------------------
 ; IGGLYBUFF EGGS
 ;-------------------------------------------------------------------------------
-; PETAL_DANCE, SCARY_FACE, MIMIC
 ; All perfect DVs
 	db IGGLYBUFF
 	db NO_ITEM
-	db SING, CHARM, DIZZY_PUNCH, PLAY_ROUGH
+	db SING, CHARM, DIZZY_PUNCH, PETAL_DANCE
 	dw 00768 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -422,7 +419,7 @@ OddEggs:
 ; One perfect DV each
 	db IGGLYBUFF
 	db NO_ITEM
-	db SING, CHARM, DIZZY_PUNCH, PLAY_ROUGH
+	db SING, CHARM, DIZZY_PUNCH, SCARY_FACE
 	dw 00768 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -448,7 +445,7 @@ OddEggs:
 
 	db IGGLYBUFF
 	db NO_ITEM
-	db SING, CHARM, DIZZY_PUNCH, PLAY_ROUGH
+	db SING, CHARM, DIZZY_PUNCH, SCARY_FACE
 	dw 00768 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -474,7 +471,7 @@ OddEggs:
 
 	db IGGLYBUFF
 	db NO_ITEM
-	db SING, CHARM, DIZZY_PUNCH, PLAY_ROUGH
+	db SING, CHARM, DIZZY_PUNCH, SCARY_FACE
 	dw 00768 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -500,7 +497,7 @@ OddEggs:
 
 	db IGGLYBUFF
 	db NO_ITEM
-	db SING, CHARM, DIZZY_PUNCH, PLAY_ROUGH
+	db SING, CHARM, DIZZY_PUNCH, SCARY_FACE
 	dw 00768 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -527,7 +524,7 @@ OddEggs:
 ; No perfect DVs
 	db IGGLYBUFF
 	db NO_ITEM
-	db SING, CHARM, DIZZY_PUNCH, PLAY_ROUGH
+	db SING, CHARM, DIZZY_PUNCH, MIMIC
 	dw 00768 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -553,11 +550,10 @@ OddEggs:
 ;-------------------------------------------------------------------------------
 ; SMOOCHUM EGGS
 ;-------------------------------------------------------------------------------
-; PETAL_DANCE, METRONOME
 ; All perfect DVs
 	db SMOOCHUM
 	db NO_ITEM
-	db POUND, LICK, DIZZY_PUNCH, PSYCHIC_M
+	db POUND, LICK, DIZZY_PUNCH, PETAL_DANCE
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -584,7 +580,7 @@ OddEggs:
 ; One perfect DV
 	db SMOOCHUM
 	db NO_ITEM
-	db POUND, LICK, DIZZY_PUNCH, PSYCHIC_M
+	db POUND, LICK, DIZZY_PUNCH, METRONOME
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -610,7 +606,7 @@ OddEggs:
 
 	db SMOOCHUM
 	db NO_ITEM
-	db POUND, LICK, DIZZY_PUNCH, PSYCHIC_M
+	db POUND, LICK, DIZZY_PUNCH, METRONOME
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -636,7 +632,7 @@ OddEggs:
 
 	db SMOOCHUM
 	db NO_ITEM
-	db POUND, LICK, DIZZY_PUNCH, PSYCHIC_M
+	db POUND, LICK, DIZZY_PUNCH, METRONOME
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -662,7 +658,7 @@ OddEggs:
 
 	db SMOOCHUM
 	db NO_ITEM
-	db POUND, LICK, DIZZY_PUNCH, PSYCHIC_M
+	db POUND, LICK, DIZZY_PUNCH, METRONOME
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -689,7 +685,7 @@ OddEggs:
 ; No perfect DVs
 	db SMOOCHUM
 	db NO_ITEM
-	db POUND, LICK, DIZZY_PUNCH, PSYCHIC_M
+	db POUND, LICK, DIZZY_PUNCH, METRONOME
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -712,13 +708,14 @@ OddEggs:
 	bigdw 6 ; SAtk
 	bigdw 6 ; SDef
 	db "EGG@@@@@@@@"
+
 ;-------------------------------------------------------------------------------
 ; MAGBY EGGS
 ;-------------------------------------------------------------------------------
 ; All perfect DVs
 	db MAGBY
 	db NO_ITEM
-	db EMBER, DIZZY_PUNCH, FIRE_BLAST, FAINT_ATTACK
+	db EMBER, DIZZY_PUNCH, FAINT_ATTACK, 0
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -728,7 +725,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 15, 15, 15, 20 ; DVs
-	db 25, 10, 5, 10 ; PP
+	db 25, 10, 20, 0 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -745,7 +742,7 @@ OddEggs:
 ; One perfect DV
 	db MAGBY
 	db NO_ITEM
-	db EMBER, DIZZY_PUNCH, FIRE_BLAST, FAINT_ATTACK
+	db EMBER, DIZZY_PUNCH, FAINT_ATTACK, 0
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -755,7 +752,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 15, 10, 10, 10 ; DVs
-	db 25, 10, 5, 20 ; PP
+	db 25, 10, 20, 0 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -771,7 +768,7 @@ OddEggs:
 
 	db MAGBY
 	db NO_ITEM
-	db EMBER, DIZZY_PUNCH, FIRE_BLAST, FAINT_ATTACK
+	db EMBER, DIZZY_PUNCH, FAINT_ATTACK, 0
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -781,7 +778,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 10, 15, 10, 10 ; DVs
-	db 25, 10, 5, 20 ; PP
+	db 25, 10, 20, 0 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -797,7 +794,7 @@ OddEggs:
 
 	db MAGBY
 	db NO_ITEM
-	db EMBER, DIZZY_PUNCH, FIRE_BLAST, FAINT_ATTACK
+	db EMBER, DIZZY_PUNCH, FAINT_ATTACK, 0
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -807,7 +804,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 10, 10, 15, 10 ; DVs
-	db 25, 10, 5, 20 ; PP
+	db 25, 10, 20, 0 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -823,7 +820,7 @@ OddEggs:
 
 	db MAGBY
 	db NO_ITEM
-	db EMBER, DIZZY_PUNCH, FIRE_BLAST, FAINT_ATTACK
+	db EMBER, DIZZY_PUNCH, FAINT_ATTACK, 0
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -833,7 +830,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 10, 10, 10, 15 ; DVs
-	db 25, 10, 5, 20 ; PP
+	db 25, 10, 20, 0 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -850,7 +847,7 @@ OddEggs:
 ; No perfect DVs
 	db MAGBY
 	db NO_ITEM
-	db EMBER, DIZZY_PUNCH, FIRE_BLAST, FAINT_ATTACK
+	db EMBER, DIZZY_PUNCH, FAINT_ATTACK, 0
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -860,7 +857,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 12, 12, 12, 12 ; DVs
-	db 25, 10, 5, 20 ; PP
+	db 25, 10, 20, 0 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -1042,7 +1039,7 @@ OddEggs:
 ; All perfect DVs
 	db TYROGUE
 	db NO_ITEM
-	db TACKLE, DIZZY_PUNCH, CROSS_CHOP, RAGE
+	db TACKLE, DIZZY_PUNCH, RAGE, 0
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -1052,7 +1049,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 15, 15, 15, 15 ; DVs
-	db 35, 10, 5, 20 ; PP
+	db 35, 10, 20, 0 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -1069,7 +1066,7 @@ OddEggs:
 ; One perfect DV
 	db TYROGUE
 	db NO_ITEM
-	db TACKLE, DIZZY_PUNCH, CROSS_CHOP, RAGE
+	db TACKLE, DIZZY_PUNCH, RAGE, 0
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -1079,7 +1076,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 15, 10, 10, 10 ; DVs
-	db 35, 10, 5, 20 ; PP
+	db 35, 10, 20, 0 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -1095,7 +1092,7 @@ OddEggs:
 
 	db TYROGUE
 	db NO_ITEM
-	db TACKLE, DIZZY_PUNCH, CROSS_CHOP, RAGE
+	db TACKLE, DIZZY_PUNCH, RAGE, 0
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -1105,7 +1102,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 10, 15, 10, 10 ; DVs
-	db 35, 10, 5, 20 ; PP
+	db 35, 10, 20, 0 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -1121,7 +1118,7 @@ OddEggs:
 
 	db TYROGUE
 	db NO_ITEM
-	db TACKLE, DIZZY_PUNCH, CROSS_CHOP, RAGE
+	db TACKLE, DIZZY_PUNCH, RAGE, 0
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -1131,7 +1128,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 10, 10, 15, 10 ; DVs
-	db 35, 10, 5, 20 ; PP
+	db 35, 10, 20, 0 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -1147,7 +1144,7 @@ OddEggs:
 
 	db TYROGUE
 	db NO_ITEM
-	db TACKLE, DIZZY_PUNCH, CROSS_CHOP, RAGE
+	db TACKLE, DIZZY_PUNCH, RAGE, 0
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -1157,7 +1154,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 10, 10, 10, 15 ; DVs
-	db 35, 10, 5, 20 ; PP
+	db 35, 10, 20, 0 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -1174,7 +1171,7 @@ OddEggs:
 ; No perfect DVs
 	db TYROGUE
 	db NO_ITEM
-	db TACKLE, DIZZY_PUNCH, CROSS_CHOP, RAGE
+	db TACKLE, DIZZY_PUNCH, RAGE, 0
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -1184,7 +1181,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 12, 12, 12, 12 ; DVs
-	db 35, 10, 5, 20 ; PP
+	db 35, 10, 20, 0 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level

--- a/data/events/odd_eggs.asm
+++ b/data/events/odd_eggs.asm
@@ -1,4 +1,4 @@
-DEF NUM_ODD_EGGS EQU 9
+DEF NUM_ODD_EGGS EQU 54
 
 MACRO prob
 	DEF prob_total += \1

--- a/data/events/odd_eggs.asm
+++ b/data/events/odd_eggs.asm
@@ -1,4 +1,4 @@
-DEF NUM_ODD_EGGS EQU 48
+DEF NUM_ODD_EGGS EQU 42
 
 MACRO prob
 	DEF prob_total += \1
@@ -15,42 +15,42 @@ DEF prob_total = 0
 	prob 2
 	prob 2
 	prob 2
-	prob 4
+	prob 5
 ; Cleffa
 	prob 1
 	prob 2
 	prob 2
 	prob 2
 	prob 2
-	prob 4
+	prob 5
 ; Igglybuff
 	prob 1
 	prob 2
 	prob 2
 	prob 2
 	prob 2
-	prob 4
+	prob 5
 ; Smoochum
 	prob 1
 	prob 2
 	prob 2
 	prob 2
 	prob 2
-	prob 3
+	prob 6
 ; Magby
 	prob 1
 	prob 2
 	prob 2
 	prob 2
 	prob 2
-	prob 3
+	prob 6
 ; Elekid
 	prob 1
 	prob 2
 	prob 2
 	prob 2
 	prob 2
-	prob 3
+	prob 6
 ; Tyrogue
 	prob 1
 	prob 2
@@ -58,13 +58,6 @@ DEF prob_total = 0
 	prob 2
 	prob 2
 	prob 4
-; Teddiursa
-	prob 1
-	prob 2
-	prob 2
-	prob 2
-	prob 2
-	prob 3
 	assert_table_length NUM_ODD_EGGS
 	assert prob_total == 100, "OddEggProbabilities do not sum to 100%!"
 
@@ -1203,168 +1196,6 @@ OddEggs:
 	bigdw 5 ; Spd
 	bigdw 5 ; SAtk
 	bigdw 5 ; SDef
-	db "EGG@@@@@@@@"
-
-;-------------------------------------------------------------------------------
-; TEDDIURSA EGGS
-;-------------------------------------------------------------------------------
-; All perfect DVs
-	db TEDDIURSA
-	db NO_ITEM
-	db SCRATCH, LEER, DIZZY_PUNCH, PLAY_ROUGH
-	dw 00256 ; OT ID
-	dt 0 ; Exp
-	; Stat exp
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	dn 15, 15, 15, 15 ; DVs
-	db 35, 30, 10, 10 ; PP
-	db 20 ; Step cycles to hatch
-	db 0, 0, 0 ; Pokerus, Caught data
-	db 1 ; Level
-	db 0, 0 ; Status
-	bigdw 0 ; HP
-	bigdw 12; Max HP
-	bigdw 6 ; Atk
-	bigdw 6 ; Def
-	bigdw 6 ; Spd
-	bigdw 6 ; SAtk
-	bigdw 6 ; SDef
-	db "EGG@@@@@@@@"
-
-; One perfect DV
-	db TEDDIURSA
-	db NO_ITEM
-	db SCRATCH, LEER, DIZZY_PUNCH, PLAY_ROUGH
-	dw 00256 ; OT ID
-	dt 0 ; Exp
-	; Stat exp
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	dn 15, 10, 10, 10 ; DVs
-	db 35, 30, 10, 10 ; PP
-	db 20 ; Step cycles to hatch
-	db 0, 0, 0 ; Pokerus, Caught data
-	db 1 ; Level
-	db 0, 0 ; Status
-	bigdw 0 ; HP
-	bigdw 12; Max HP
-	bigdw 6 ; Atk
-	bigdw 6 ; Def
-	bigdw 6 ; Spd
-	bigdw 6 ; SAtk
-	bigdw 6 ; SDef
-	db "EGG@@@@@@@@"
-
-	db TEDDIURSA
-	db NO_ITEM
-	db SCRATCH, LEER, DIZZY_PUNCH, PLAY_ROUGH
-	dw 00256 ; OT ID
-	dt 0 ; Exp
-	; Stat exp
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	dn 10, 15, 10, 10 ; DVs
-	db 35, 30, 10, 10 ; PP
-	db 20 ; Step cycles to hatch
-	db 0, 0, 0 ; Pokerus, Caught data
-	db 1 ; Level
-	db 0, 0 ; Status
-	bigdw 0 ; HP
-	bigdw 12; Max HP
-	bigdw 6 ; Atk
-	bigdw 6 ; Def
-	bigdw 6 ; Spd
-	bigdw 6 ; SAtk
-	bigdw 6 ; SDef
-	db "EGG@@@@@@@@"
-
-	db TEDDIURSA
-	db NO_ITEM
-	db SCRATCH, LEER, DIZZY_PUNCH, PLAY_ROUGH
-	dw 00256 ; OT ID
-	dt 0 ; Exp
-	; Stat exp
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	dn 10, 10, 15, 10 ; DVs
-	db 35, 30, 10, 10 ; PP
-	db 20 ; Step cycles to hatch
-	db 0, 0, 0 ; Pokerus, Caught data
-	db 1 ; Level
-	db 0, 0 ; Status
-	bigdw 0 ; HP
-	bigdw 12; Max HP
-	bigdw 6 ; Atk
-	bigdw 6 ; Def
-	bigdw 6 ; Spd
-	bigdw 6 ; SAtk
-	bigdw 6 ; SDef
-	db "EGG@@@@@@@@"
-
-	db TEDDIURSA
-	db NO_ITEM
-	db SCRATCH, LEER, DIZZY_PUNCH, PLAY_ROUGH
-	dw 00256 ; OT ID
-	dt 0 ; Exp
-	; Stat exp
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	dn 10, 10, 10, 15 ; DVs
-	db 35, 30, 10, 10 ; PP
-	db 20 ; Step cycles to hatch
-	db 0, 0, 0 ; Pokerus, Caught data
-	db 1 ; Level
-	db 0, 0 ; Status
-	bigdw 0 ; HP
-	bigdw 12; Max HP
-	bigdw 6 ; Atk
-	bigdw 6 ; Def
-	bigdw 6 ; Spd
-	bigdw 6 ; SAtk
-	bigdw 6 ; SDef
-	db "EGG@@@@@@@@"
-
-; No perfect DVs
-	db TEDDIURSA
-	db NO_ITEM
-	db SCRATCH, LEER, DIZZY_PUNCH, PLAY_ROUGH
-	dw 00256 ; OT ID
-	dt 0 ; Exp
-	; Stat exp
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	dn 12, 12, 12, 12 ; DVs
-	db 35, 30, 10, 10 ; PP
-	db 20 ; Step cycles to hatch
-	db 0, 0, 0 ; Pokerus, Caught data
-	db 1 ; Level
-	db 0, 0 ; Status
-	bigdw 0 ; HP
-	bigdw 12; Max HP
-	bigdw 6 ; Atk
-	bigdw 6 ; Def
-	bigdw 6 ; Spd
-	bigdw 6 ; SAtk
-	bigdw 6 ; SDef
 	db "EGG@@@@@@@@"
 
 ;-------------------------------------------------------------------------------

--- a/data/events/odd_eggs.asm
+++ b/data/events/odd_eggs.asm
@@ -44,7 +44,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	bigdw 0
-	dn 31, 31, 31, 31 ; DVs
+	dn 15, 15, 15, 15 ; DVs
 	db 30, 20, 10, 5 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
@@ -70,7 +70,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	bigdw 0
-	dn 31, 31, 31, 31 ; DVs
+	dn 15, 15, 15, 15 ; DVs
 	db 35, 20, 10, 10 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
@@ -96,7 +96,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	bigdw 0
-	dn 31, 31, 31, 31 ; DVs
+	dn 15, 15, 15, 15 ; DVs
 	db 15, 20, 10, 10 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
@@ -122,7 +122,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	bigdw 0
-	dn 31, 31, 31, 31 ; DVs
+	dn 15, 15, 15, 15 ; DVs
 	db 35, 30, 10, 10 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
@@ -148,7 +148,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	bigdw 0
-	dn 31, 31, 31, 31 ; DVs
+	dn 15, 15, 15, 15 ; DVs
 	db 25, 10, 5, 10 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
@@ -174,7 +174,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	bigdw 0
-	dn 31, 31, 31, 31 ; DVs
+	dn 15, 15, 15, 15 ; DVs
 	db 30, 30, 10, 5 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
@@ -200,7 +200,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	bigdw 0
-	dn 31, 31, 31, 31 ; DVs
+	dn 15, 15, 15, 15 ; DVs
 	db 35, 10, 5, 15 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
@@ -226,7 +226,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	bigdw 0
-	dn 31, 31, 31, 31 ; DVs
+	dn 15, 15, 15, 15 ; DVs
 	db 25, 30, 10, 10 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
@@ -252,7 +252,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	bigdw 0
-	dn 31, 31, 31, 31 ; DVs
+	dn 15, 15, 15, 15 ; DVs
 	db 35, 30, 10, 10 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data

--- a/data/events/odd_eggs.asm
+++ b/data/events/odd_eggs.asm
@@ -1,4 +1,4 @@
-DEF NUM_ODD_EGGS EQU 54
+DEF NUM_ODD_EGGS EQU 48
 
 MACRO prob
 	DEF prob_total += \1
@@ -15,63 +15,56 @@ DEF prob_total = 0
 	prob 2
 	prob 2
 	prob 2
-	prob 3
+	prob 4
 ; Cleffa
 	prob 1
 	prob 2
 	prob 2
 	prob 2
 	prob 2
-	prob 2
+	prob 4
 ; Igglybuff
 	prob 1
 	prob 2
 	prob 2
 	prob 2
 	prob 2
-	prob 2
+	prob 4
 ; Smoochum
 	prob 1
 	prob 2
 	prob 2
 	prob 2
 	prob 2
-	prob 2
+	prob 3
 ; Magby
 	prob 1
 	prob 2
 	prob 2
 	prob 2
 	prob 2
-	prob 2
+	prob 3
 ; Elekid
 	prob 1
 	prob 2
 	prob 2
 	prob 2
 	prob 2
-	prob 2
+	prob 3
 ; Tyrogue
 	prob 1
 	prob 2
 	prob 2
 	prob 2
 	prob 2
-	prob 2
-; Larvitar
-	prob 1
-	prob 2
-	prob 2
-	prob 2
-	prob 2
-	prob 2
+	prob 4
 ; Teddiursa
 	prob 1
 	prob 2
 	prob 2
 	prob 2
 	prob 2
-	prob 2
+	prob 3
 	assert_table_length NUM_ODD_EGGS
 	assert prob_total == 100, "OddEggProbabilities do not sum to 100%!"
 
@@ -1210,168 +1203,6 @@ OddEggs:
 	bigdw 5 ; Spd
 	bigdw 5 ; SAtk
 	bigdw 5 ; SDef
-	db "EGG@@@@@@@@"
-
-;-----------------------------------------------------------------------------
-; LARVITAR EGG
-;-----------------------------------------------------------------------------
-; All perfect DVs
-	db LARVITAR
-	db NO_ITEM
-	db BITE, LEER, DIZZY_PUNCH, RAGE
-	dw 00256 ; OT ID
-	dt 0 ; Exp
-	; Stat exp
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	dn 15, 15, 15, 15 ; DVs
-	db 25, 30, 10, 20 ; PP
-	db 20 ; Step cycles to hatch
-	db 0, 0, 0 ; Pokerus, Caught data
-	db 1 ; Level
-	db 0, 0 ; Status
-	bigdw 0 ; HP
-	bigdw 12; Max HP
-	bigdw 6 ; Atk
-	bigdw 6 ; Def
-	bigdw 6 ; Spd
-	bigdw 6 ; SAtk
-	bigdw 6 ; SDef
-	db "EGG@@@@@@@@"
-
-; One perfect DV
-	db LARVITAR
-	db NO_ITEM
-	db BITE, LEER, DIZZY_PUNCH, RAGE
-	dw 00256 ; OT ID
-	dt 0 ; Exp
-	; Stat exp
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	dn 15, 10, 10, 10 ; DVs
-	db 25, 30, 10, 20 ; PP
-	db 20 ; Step cycles to hatch
-	db 0, 0, 0 ; Pokerus, Caught data
-	db 1 ; Level
-	db 0, 0 ; Status
-	bigdw 0 ; HP
-	bigdw 12; Max HP
-	bigdw 6 ; Atk
-	bigdw 6 ; Def
-	bigdw 6 ; Spd
-	bigdw 6 ; SAtk
-	bigdw 6 ; SDef
-	db "EGG@@@@@@@@"
-
-	db LARVITAR
-	db NO_ITEM
-	db BITE, LEER, DIZZY_PUNCH, RAGE
-	dw 00256 ; OT ID
-	dt 0 ; Exp
-	; Stat exp
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	dn 10, 15, 10, 10 ; DVs
-	db 25, 30, 10, 20 ; PP
-	db 20 ; Step cycles to hatch
-	db 0, 0, 0 ; Pokerus, Caught data
-	db 1 ; Level
-	db 0, 0 ; Status
-	bigdw 0 ; HP
-	bigdw 12; Max HP
-	bigdw 6 ; Atk
-	bigdw 6 ; Def
-	bigdw 6 ; Spd
-	bigdw 6 ; SAtk
-	bigdw 6 ; SDef
-	db "EGG@@@@@@@@"
-
-	db LARVITAR
-	db NO_ITEM
-	db BITE, LEER, DIZZY_PUNCH, RAGE
-	dw 00256 ; OT ID
-	dt 0 ; Exp
-	; Stat exp
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	dn 10, 10, 15, 10 ; DVs
-	db 25, 30, 10, 20 ; PP
-	db 20 ; Step cycles to hatch
-	db 0, 0, 0 ; Pokerus, Caught data
-	db 1 ; Level
-	db 0, 0 ; Status
-	bigdw 0 ; HP
-	bigdw 12; Max HP
-	bigdw 6 ; Atk
-	bigdw 6 ; Def
-	bigdw 6 ; Spd
-	bigdw 6 ; SAtk
-	bigdw 6 ; SDef
-	db "EGG@@@@@@@@"
-
-	db LARVITAR
-	db NO_ITEM
-	db BITE, LEER, DIZZY_PUNCH, RAGE
-	dw 00256 ; OT ID
-	dt 0 ; Exp
-	; Stat exp
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	dn 10, 10, 10, 15 ; DVs
-	db 25, 30, 10, 20 ; PP
-	db 20 ; Step cycles to hatch
-	db 0, 0, 0 ; Pokerus, Caught data
-	db 1 ; Level
-	db 0, 0 ; Status
-	bigdw 0 ; HP
-	bigdw 12; Max HP
-	bigdw 6 ; Atk
-	bigdw 6 ; Def
-	bigdw 6 ; Spd
-	bigdw 6 ; SAtk
-	bigdw 6 ; SDef
-	db "EGG@@@@@@@@"
-
-; No perfect DVs
-	db LARVITAR
-	db NO_ITEM
-	db BITE, LEER, DIZZY_PUNCH, RAGE
-	dw 00256 ; OT ID
-	dt 0 ; Exp
-	; Stat exp
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	bigdw 0
-	dn 12, 12, 12, 12 ; DVs
-	db 25, 30, 10, 20 ; PP
-	db 20 ; Step cycles to hatch
-	db 0, 0, 0 ; Pokerus, Caught data
-	db 1 ; Level
-	db 0, 0 ; Status
-	bigdw 0 ; HP
-	bigdw 12; Max HP
-	bigdw 6 ; Atk
-	bigdw 6 ; Def
-	bigdw 6 ; Spd
-	bigdw 6 ; SAtk
-	bigdw 6 ; SDef
 	db "EGG@@@@@@@@"
 
 ;-------------------------------------------------------------------------------

--- a/data/events/odd_eggs.asm
+++ b/data/events/odd_eggs.asm
@@ -10,29 +10,79 @@ OddEggProbabilities:
 	table_width 2, OddEggProbabilities
 DEF prob_total = 0
 ; Pichu
-	prob 12
+	prob 1
+	prob 2
+	prob 2
+	prob 2
+	prob 2
+	prob 3
 ; Cleffa
-	prob 11
+	prob 1
+	prob 2
+	prob 2
+	prob 2
+	prob 2
+	prob 2
 ; Igglybuff
-	prob 11
+	prob 1
+	prob 2
+	prob 2
+	prob 2
+	prob 2
+	prob 2
 ; Smoochum
-	prob 11
+	prob 1
+	prob 2
+	prob 2
+	prob 2
+	prob 2
+	prob 2
 ; Magby
-	prob 11
+	prob 1
+	prob 2
+	prob 2
+	prob 2
+	prob 2
+	prob 2
 ; Elekid
-	prob 11
+	prob 1
+	prob 2
+	prob 2
+	prob 2
+	prob 2
+	prob 2
 ; Tyrogue
-	prob 11
+	prob 1
+	prob 2
+	prob 2
+	prob 2
+	prob 2
+	prob 2
 ; Larvitar
-	prob 11
+	prob 1
+	prob 2
+	prob 2
+	prob 2
+	prob 2
+	prob 2
 ; Teddiursa
-	prob 11
+	prob 1
+	prob 2
+	prob 2
+	prob 2
+	prob 2
+	prob 2
 	assert_table_length NUM_ODD_EGGS
 	assert prob_total == 100, "OddEggProbabilities do not sum to 100%!"
 
 OddEggs:
 	table_width NICKNAMED_MON_STRUCT_LENGTH, OddEggs
 
+;-------------------------------------------------------------------------------
+; PICHU EGGS
+;-------------------------------------------------------------------------------
+; PETAL_DANCE, SCARY_FACE, SING
+; All 15 DVs
 	db PICHU
 	db NO_ITEM
 	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, ZAP_CANNON
@@ -59,6 +109,142 @@ OddEggs:
 	bigdw 5 ; SDef
 	db "EGG@@@@@@@@"
 
+; One 15 DV each
+	db PICHU
+	db NO_ITEM
+	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, ZAP_CANNON
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 15, 10, 10, 10 ; DVs
+	db 30, 20, 10, 5 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 5 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+
+	db PICHU
+	db NO_ITEM
+	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, ZAP_CANNON
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 15, 10, 10 ; DVs
+	db 30, 20, 10, 5 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 5 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+
+	db PICHU
+	db NO_ITEM
+	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, ZAP_CANNON
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 15, 10 ; DVs
+	db 30, 20, 10, 5 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 5 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+
+	db PICHU
+	db NO_ITEM
+	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, ZAP_CANNON
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 10, 15 ; DVs
+	db 30, 20, 10, 5 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 5 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+
+; No 15 DVs
+	db PICHU
+	db NO_ITEM
+	db THUNDERSHOCK, CHARM, DIZZY_PUNCH, ZAP_CANNON
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 12, 12, 12, 12 ; DVs
+	db 30, 20, 10, 5 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 5 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+;-------------------------------------------------------------------------------
+; CLEFFA EGGS
+;-------------------------------------------------------------------------------
+; PETAL_DANCE, SCARY_FACE, SWIFT
+; All 15 DVs
 	db CLEFFA
 	db NO_ITEM
 	db POUND, CHARM, DIZZY_PUNCH, MOONBLAST
@@ -85,6 +271,142 @@ OddEggs:
 	bigdw 6 ; SDef
 	db "EGG@@@@@@@@"
 
+; One DV of 15 each
+	db CLEFFA
+	db NO_ITEM
+	db POUND, CHARM, DIZZY_PUNCH, MOONBLAST
+	dw 00768 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 15, 10, 10, 10 ; DVs
+	db 35, 20, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db CLEFFA
+	db NO_ITEM
+	db POUND, CHARM, DIZZY_PUNCH, MOONBLAST
+	dw 00768 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 15, 10, 10 ; DVs
+	db 35, 20, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db CLEFFA
+	db NO_ITEM
+	db POUND, CHARM, DIZZY_PUNCH, MOONBLAST
+	dw 00768 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 15, 10 ; DVs
+	db 35, 20, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db CLEFFA
+	db NO_ITEM
+	db POUND, CHARM, DIZZY_PUNCH, MOONBLAST
+	dw 00768 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 10, 15 ; DVs
+	db 35, 20, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+; No 15 DVs
+	db CLEFFA
+	db NO_ITEM
+	db POUND, CHARM, DIZZY_PUNCH, MOONBLAST
+	dw 00768 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 12, 12, 12, 12 ; DVs
+	db 35, 20, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+;-------------------------------------------------------------------------------
+; IGGLYBUFF EGGS
+;-------------------------------------------------------------------------------
+; PETAL_DANCE, SCARY_FACE, MIMIC
+; All perfect DVs
 	db IGGLYBUFF
 	db NO_ITEM
 	db SING, CHARM, DIZZY_PUNCH, PLAY_ROUGH
@@ -111,6 +433,142 @@ OddEggs:
 	bigdw 5 ; SDef
 	db "EGG@@@@@@@@"
 
+; One perfect DV each
+	db IGGLYBUFF
+	db NO_ITEM
+	db SING, CHARM, DIZZY_PUNCH, PLAY_ROUGH
+	dw 00768 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 15, 10, 10, 10 ; DVs
+	db 15, 20, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+
+	db IGGLYBUFF
+	db NO_ITEM
+	db SING, CHARM, DIZZY_PUNCH, PLAY_ROUGH
+	dw 00768 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 15, 10, 10 ; DVs
+	db 15, 20, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+
+	db IGGLYBUFF
+	db NO_ITEM
+	db SING, CHARM, DIZZY_PUNCH, PLAY_ROUGH
+	dw 00768 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 15, 10 ; DVs
+	db 15, 20, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+
+	db IGGLYBUFF
+	db NO_ITEM
+	db SING, CHARM, DIZZY_PUNCH, PLAY_ROUGH
+	dw 00768 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 10, 15 ; DVs
+	db 15, 20, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+
+; No perfect DVs
+	db IGGLYBUFF
+	db NO_ITEM
+	db SING, CHARM, DIZZY_PUNCH, PLAY_ROUGH
+	dw 00768 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 12, 12, 12, 12 ; DVs
+	db 15, 20, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+;-------------------------------------------------------------------------------
+; SMOOCHUM EGGS
+;-------------------------------------------------------------------------------
+; PETAL_DANCE, METRONOME
+; All perfect DVs
 	db SMOOCHUM
 	db NO_ITEM
 	db POUND, LICK, DIZZY_PUNCH, PSYCHIC_M
@@ -137,9 +595,10 @@ OddEggs:
 	bigdw 6 ; SDef
 	db "EGG@@@@@@@@"
 
-	db MAGBY
+; One perfect DV
+	db SMOOCHUM
 	db NO_ITEM
-	db EMBER, DIZZY_PUNCH, FIRE_BLAST, THIEF
+	db POUND, LICK, DIZZY_PUNCH, PSYCHIC_M
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -148,7 +607,141 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	bigdw 0
-	dn 15, 15, 15, 15 ; DVs
+	dn 15, 10, 10, 10 ; DVs
+	db 35, 30, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db SMOOCHUM
+	db NO_ITEM
+	db POUND, LICK, DIZZY_PUNCH, PSYCHIC_M
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 15, 10, 10 ; DVs
+	db 35, 30, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db SMOOCHUM
+	db NO_ITEM
+	db POUND, LICK, DIZZY_PUNCH, PSYCHIC_M
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 15, 10 ; DVs
+	db 35, 30, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db SMOOCHUM
+	db NO_ITEM
+	db POUND, LICK, DIZZY_PUNCH, PSYCHIC_M
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 10, 15 ; DVs
+	db 35, 30, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+; No perfect DVs
+	db SMOOCHUM
+	db NO_ITEM
+	db POUND, LICK, DIZZY_PUNCH, PSYCHIC_M
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 12, 12, 12, 12 ; DVs
+	db 35, 30, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+;-------------------------------------------------------------------------------
+; MAGBY EGGS
+;-------------------------------------------------------------------------------
+; All perfect DVs
+	db MAGBY
+	db NO_ITEM
+	db EMBER, DIZZY_PUNCH, FIRE_BLAST, FAINT_ATTACK
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 15, 15, 15, 20 ; DVs
 	db 25, 10, 5, 10 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
@@ -163,9 +756,145 @@ OddEggs:
 	bigdw 6 ; SDef
 	db "EGG@@@@@@@@"
 
+; One perfect DV
+	db MAGBY
+	db NO_ITEM
+	db EMBER, DIZZY_PUNCH, FIRE_BLAST, FAINT_ATTACK
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 15, 10, 10, 10 ; DVs
+	db 25, 10, 5, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db MAGBY
+	db NO_ITEM
+	db EMBER, DIZZY_PUNCH, FIRE_BLAST, FAINT_ATTACK
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 15, 10, 10 ; DVs
+	db 25, 10, 5, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db MAGBY
+	db NO_ITEM
+	db EMBER, DIZZY_PUNCH, FIRE_BLAST, FAINT_ATTACK
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 15, 10 ; DVs
+	db 25, 10, 5, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db MAGBY
+	db NO_ITEM
+	db EMBER, DIZZY_PUNCH, FIRE_BLAST, FAINT_ATTACK
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 10, 15 ; DVs
+	db 25, 10, 5, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+; No perfect DVs
+	db MAGBY
+	db NO_ITEM
+	db EMBER, DIZZY_PUNCH, FIRE_BLAST, FAINT_ATTACK
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 12, 12, 12, 12 ; DVs
+	db 25, 10, 5, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+;-------------------------------------------------------------------------------
+; ELEKID EGGS
+;-------------------------------------------------------------------------------
+; All perfect DVs
 	db ELEKID
 	db NO_ITEM
-	db QUICK_ATTACK, LEER, DIZZY_PUNCH, ZAP_CANNON
+	db QUICK_ATTACK, LEER, DIZZY_PUNCH, PURSUIT
 	dw 00512 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -175,7 +904,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 15, 15, 15, 15 ; DVs
-	db 30, 30, 10, 5 ; PP
+	db 30, 30, 10, 20 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -189,9 +918,145 @@ OddEggs:
 	bigdw 6 ; SDef
 	db "EGG@@@@@@@@"
 
+; One perfect DV
+	db ELEKID
+	db NO_ITEM
+	db QUICK_ATTACK, LEER, DIZZY_PUNCH, PURSUIT
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 15, 10, 10, 10 ; DVs
+	db 30, 30, 10, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 7 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db ELEKID
+	db NO_ITEM
+	db QUICK_ATTACK, LEER, DIZZY_PUNCH, PURSUIT
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 15, 10, 10 ; DVs
+	db 30, 30, 10, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 7 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db ELEKID
+	db NO_ITEM
+	db QUICK_ATTACK, LEER, DIZZY_PUNCH, PURSUIT
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 15, 10 ; DVs
+	db 30, 30, 10, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 7 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db ELEKID
+	db NO_ITEM
+	db QUICK_ATTACK, LEER, DIZZY_PUNCH, PURSUIT
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 10, 15 ; DVs
+	db 30, 30, 10, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 7 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+; No perfect DVs
+	db ELEKID
+	db NO_ITEM
+	db QUICK_ATTACK, LEER, DIZZY_PUNCH, PURSUIT
+	dw 00512 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 12, 12, 12, 12 ; DVs
+	db 30, 30, 10, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 6 ; Atk
+	bigdw 5 ; Def
+	bigdw 7 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+;-------------------------------------------------------------------------------
+; TYROGUE EGGS
+;-------------------------------------------------------------------------------
+; All perfect DVs
 	db TYROGUE
 	db NO_ITEM
-	db TACKLE, DIZZY_PUNCH, CROSS_CHOP, REVERSAL
+	db TACKLE, DIZZY_PUNCH, CROSS_CHOP, RAGE
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -201,7 +1066,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 15, 15, 15, 15 ; DVs
-	db 35, 10, 5, 15 ; PP
+	db 35, 10, 5, 20 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -215,9 +1080,145 @@ OddEggs:
 	bigdw 5 ; SDef
 	db "EGG@@@@@@@@"
 
+; One perfect DV
+	db TYROGUE
+	db NO_ITEM
+	db TACKLE, DIZZY_PUNCH, CROSS_CHOP, RAGE
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 15, 10, 10, 10 ; DVs
+	db 35, 10, 5, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 5 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+
+	db TYROGUE
+	db NO_ITEM
+	db TACKLE, DIZZY_PUNCH, CROSS_CHOP, RAGE
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 15, 10, 10 ; DVs
+	db 35, 10, 5, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 5 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+
+	db TYROGUE
+	db NO_ITEM
+	db TACKLE, DIZZY_PUNCH, CROSS_CHOP, RAGE
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 15, 10 ; DVs
+	db 35, 10, 5, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 5 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+
+	db TYROGUE
+	db NO_ITEM
+	db TACKLE, DIZZY_PUNCH, CROSS_CHOP, RAGE
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 10, 15 ; DVs
+	db 35, 10, 5, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 5 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+
+; No perfect DVs
+	db TYROGUE
+	db NO_ITEM
+	db TACKLE, DIZZY_PUNCH, CROSS_CHOP, RAGE
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 12, 12, 12, 12 ; DVs
+	db 35, 10, 5, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 11 ; Max HP
+	bigdw 5 ; Atk
+	bigdw 5 ; Def
+	bigdw 5 ; Spd
+	bigdw 5 ; SAtk
+	bigdw 5 ; SDef
+	db "EGG@@@@@@@@"
+
+;-----------------------------------------------------------------------------
+; LARVITAR EGG
+;-----------------------------------------------------------------------------
+; All perfect DVs
 	db LARVITAR
 	db NO_ITEM
-	db BITE, LEER, DIZZY_PUNCH, OUTRAGE
+	db BITE, LEER, DIZZY_PUNCH, RAGE
 	dw 00256 ; OT ID
 	dt 0 ; Exp
 	; Stat exp
@@ -227,7 +1228,7 @@ OddEggs:
 	bigdw 0
 	bigdw 0
 	dn 15, 15, 15, 15 ; DVs
-	db 25, 30, 10, 10 ; PP
+	db 25, 30, 10, 20 ; PP
 	db 20 ; Step cycles to hatch
 	db 0, 0, 0 ; Pokerus, Caught data
 	db 1 ; Level
@@ -241,6 +1242,142 @@ OddEggs:
 	bigdw 6 ; SDef
 	db "EGG@@@@@@@@"
 
+; One perfect DV
+	db LARVITAR
+	db NO_ITEM
+	db BITE, LEER, DIZZY_PUNCH, RAGE
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 15, 10, 10, 10 ; DVs
+	db 25, 30, 10, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12; Max HP
+	bigdw 6 ; Atk
+	bigdw 6 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db LARVITAR
+	db NO_ITEM
+	db BITE, LEER, DIZZY_PUNCH, RAGE
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 15, 10, 10 ; DVs
+	db 25, 30, 10, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12; Max HP
+	bigdw 6 ; Atk
+	bigdw 6 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db LARVITAR
+	db NO_ITEM
+	db BITE, LEER, DIZZY_PUNCH, RAGE
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 15, 10 ; DVs
+	db 25, 30, 10, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12; Max HP
+	bigdw 6 ; Atk
+	bigdw 6 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db LARVITAR
+	db NO_ITEM
+	db BITE, LEER, DIZZY_PUNCH, RAGE
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 10, 15 ; DVs
+	db 25, 30, 10, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12; Max HP
+	bigdw 6 ; Atk
+	bigdw 6 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+; No perfect DVs
+	db LARVITAR
+	db NO_ITEM
+	db BITE, LEER, DIZZY_PUNCH, RAGE
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 12, 12, 12, 12 ; DVs
+	db 25, 30, 10, 20 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12; Max HP
+	bigdw 6 ; Atk
+	bigdw 6 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+;-------------------------------------------------------------------------------
+; TEDDIURSA EGGS
+;-------------------------------------------------------------------------------
+; All perfect DVs
 	db TEDDIURSA
 	db NO_ITEM
 	db SCRATCH, LEER, DIZZY_PUNCH, PLAY_ROUGH
@@ -267,4 +1404,137 @@ OddEggs:
 	bigdw 6 ; SDef
 	db "EGG@@@@@@@@"
 
+; One perfect DV
+	db TEDDIURSA
+	db NO_ITEM
+	db SCRATCH, LEER, DIZZY_PUNCH, PLAY_ROUGH
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 15, 10, 10, 10 ; DVs
+	db 35, 30, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12; Max HP
+	bigdw 6 ; Atk
+	bigdw 6 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db TEDDIURSA
+	db NO_ITEM
+	db SCRATCH, LEER, DIZZY_PUNCH, PLAY_ROUGH
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 15, 10, 10 ; DVs
+	db 35, 30, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12; Max HP
+	bigdw 6 ; Atk
+	bigdw 6 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db TEDDIURSA
+	db NO_ITEM
+	db SCRATCH, LEER, DIZZY_PUNCH, PLAY_ROUGH
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 15, 10 ; DVs
+	db 35, 30, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12; Max HP
+	bigdw 6 ; Atk
+	bigdw 6 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+	db TEDDIURSA
+	db NO_ITEM
+	db SCRATCH, LEER, DIZZY_PUNCH, PLAY_ROUGH
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 10, 10, 10, 15 ; DVs
+	db 35, 30, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12; Max HP
+	bigdw 6 ; Atk
+	bigdw 6 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+; No perfect DVs
+	db TEDDIURSA
+	db NO_ITEM
+	db SCRATCH, LEER, DIZZY_PUNCH, PLAY_ROUGH
+	dw 00256 ; OT ID
+	dt 0 ; Exp
+	; Stat exp
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	bigdw 0
+	dn 12, 12, 12, 12 ; DVs
+	db 35, 30, 10, 10 ; PP
+	db 20 ; Step cycles to hatch
+	db 0, 0, 0 ; Pokerus, Caught data
+	db 1 ; Level
+	db 0, 0 ; Status
+	bigdw 0 ; HP
+	bigdw 12; Max HP
+	bigdw 6 ; Atk
+	bigdw 6 ; Def
+	bigdw 6 ; Spd
+	bigdw 6 ; SAtk
+	bigdw 6 ; SDef
+	db "EGG@@@@@@@@"
+
+;-------------------------------------------------------------------------------
 	assert_table_length NUM_ODD_EGGS


### PR DESCRIPTION
Odd Egg DVs were incorrect, based on 5-bit (max 31) and not 4-bit (max 15) values. Additionally included more variance in eggs to more resemble the original game.